### PR TITLE
doc: indent use-package sexp + remove ensure keyword

### DIFF
--- a/README.org
+++ b/README.org
@@ -49,13 +49,12 @@ org-hyperschedule is *not* currently available in MELPA. Once the package mature
 For now you can either download the source and install it manually or with ~use-package~ and [[https://github.com/raxod502/straight.el][straight.el]]:
 
 #+begin_src elisp
-  (use-package org-hyperscheduler
-    :ensure t
-    :straight
-    (:repo "dmitrym0/org-hyperscheduler"
-           :host github
-           :type git
-           :files ("*")))
+(use-package org-hyperscheduler
+  :straight
+  ( :repo "dmitrym0/org-hyperscheduler"
+    :host github
+    :type git
+    :files ("*")))
 #+end_src
 
 


### PR DESCRIPTION

# Avoiding ensure and straight in the same use-package sexp

The use of the `:ensure` and `:straight` keywords in the same use-package call seems to be [discouraged by the author of straight](https://github.com/raxod502/straight.el/issues/425#issuecomment-546706730) and thus this PR proposes removing the =:ensure t= bit to avoid confusion as we're clearly opting to let straight install from git (and we never really intended to install from package.el).

# Formatting with a focus on readability

The sexp was reindented using `indent-region` which removed leading whitespace 🤷🏿‍♂️ in the altered source block (sorry for the larger diff).

What is perhaps more useful (to human readers), is the space that I added before `:repo` to trick the emacs indenter to format the sexp in a manner that more clearly outlines the relationship between the keywords (siblings = same level = left align on same column position = better visual hierarchy) which kind of gets lost in the older indentation.

I considered rephrasing the value of the `straight` keyword to the _long-form_:

```elisp
(org-hyperscheduler :repo "dmitrym0/org-hyperscheduler"
                    :host github
                    :type git
                    :files ("*"))
```

instead of the current _short-form_:

```elisp
( :repo "dmitrym0/org-hyperscheduler"
  :host github
  :type git
  :files ("*"))
```

but since the [straight README](
https://github.com/raxod502/straight.el#integration-with-use-package-1) outlines that the _short-form_ macroexpands to contain the _package name_ (which looks more like the _long-form_), I have no reason to be difficult and poke the bear so, I'm leaving this alone.