### PR TITLE
Use `defalias` to define `org-hs-open`

### DIFF
--- a/org-hyperscheduler.el
+++ b/org-hyperscheduler.el
@@ -273,8 +273,6 @@ Takes _WS and FRAME as arguments."
   (let ((html-file-path  (format "file://%s/calendar/index.html" org-hyperscheduler-root-dir)))
   (browse-url html-file-path)))
 
-(defun org-hs-open ()
-  (org-hyperscheduler-open))
-
+(defalias 'org-hs-open #'org-hyperscheduler-open)
 
 (provide 'org-hyperscheduler)


### PR DESCRIPTION
The advantage is just making it more obvious that it's just an alias and not doing anything else. E.g. when consulting `M-x describe-variable org-hs-open`, emacs will tell the user that it's an alias.