### PR TITLE
Add autoload magic comments for `org-hyperscheduler-open` functions

### DIFF
--- a/org-hyperscheduler.el
+++ b/org-hyperscheduler.el
@@ -267,13 +267,17 @@ Takes _WS and FRAME as arguments."
           "."))
 
 
+;;;###autoload
 (defun org-hyperscheduler-open ()
-  "Open org-hyperscheduler in the browser"
+  "Open org-hyperscheduler in the browser."
   (interactive)
   (let ((html-file-path  (format "file://%s/calendar/index.html" org-hyperscheduler-root-dir)))
   (browse-url html-file-path)))
 
+;;;###autoload
 (defun org-hs-open ()
+  "Open org-hyperscheduler in the browser. Alias for org-hs-open."
+  (interactive)
   (org-hyperscheduler-open))
 
 


### PR DESCRIPTION
These magic commands are expanded to autoload-function-calls when the package is compiled. They allow the main interactive entry functions to be before the package has been loaded. I.e. this means that one can add `:defer t` to the use-package declaration and then have it be loaded lazily only once one of the autoloaded commands is called. Alternatively, the user could also add them to the `:commands` use-package keyword, however I prefer doing that for them for the main commands.

Also I made org-hs-open interactive, which I think it's meant to be as it's not used anywhere else in the code and thus probably just an alias? Anyway, this will probably be better solved by my other PR #6, possibly we might have to solve a merge-conflict when merging both, but I don't think it's a problem.

Also for main functions that I touched in this PR I added a dot to the end of the docstring because my emacs checkdoc checker (which I use via flycheck) complained the docstring should end with a dot.