### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/org-hyperscheduler.el
+++ b/org-hyperscheduler.el
@@ -35,6 +35,7 @@
 
 ;; ---------------------------------------------------------------------------------------------------
 (require 'org)
+(require 'org-element)
 (require 'websocket)
 (require 'cl-lib)
 
@@ -99,16 +100,17 @@ this setting to take effect."
 ; modify the agenda filter if we want to hide done tasks.
 (and org-hyperscheduler-hide-done-tasks (setq org-hyperscheduler-agenda-filter (format "%s/-DONE" org-hyperscheduler-agenda-filter)))
 
-(setq org-hyperscheduler-ws-server
-    ; only run the server if we are not in test env.
-    (unless (boundp 'org-hyperscheduler-test-env)
-          (websocket-server
-           44445
-           :host 'local
-           :on-open #'org-hyperscheduler--ws-on-open
-           :on-message #'org-hyperscheduler--ws-on-message
-           :on-close #'org-hyperscheduler--ws-on-close)))
+(defvar org-hyperscheduler-ws-server
+  ;; only run the server if we are not in test env.
+  (unless (boundp 'org-hyperscheduler-test-env)
+    (websocket-server
+     44445
+     :host 'local
+     :on-open #'org-hyperscheduler--ws-on-open
+     :on-message #'org-hyperscheduler--ws-on-message
+     :on-close #'org-hyperscheduler--ws-on-close)))
 
+(defvar org-hyperscheduler-ws-socket nil)
 
 (defun org-hyperscheduler-stop-server ()
   "Stops the websocket server and closed connections."


### PR DESCRIPTION
- load org-element for using its functions
- declare global variables by defvar instead of setq

```
In org-hyperscheduler-stop-server:
org-hyperscheduler.el:116:27: Warning: reference to free variable ‘org-hyperscheduler-ws-server’

In org-hyperscheduler--ws-on-open:
org-hyperscheduler.el:141:11: Warning: assignment to free variable ‘org-hyperscheduler-ws-socket’

In org-hyperscheduler--get-agenda:
org-hyperscheduler.el:181:27: Warning: reference to free variable ‘org-hyperscheduler-ws-socket’

In end of data:
org-hyperscheduler.el:218:28: Warning: the function ‘org-element-property’ is not known to be defined.
```